### PR TITLE
fix resize 300x300 issue

### DIFF
--- a/src/edge/EdgeSolution/modules/streamingmodule/app/models.py
+++ b/src/edge/EdgeSolution/modules/streamingmodule/app/models.py
@@ -68,15 +68,11 @@ class ObjectDetectionModel(Model):
     def process(self, frame):
 
         # FIXME should resize according to model input size
-        img = cv2.resize(frame.image.image_pointer, (300, 300))
-        width = 300
-        height = 300
-        #img = frame.image.image_pointer
-        #width = frame.image.properties.width
-        #height = frame.image.properties.height
+        img_to_predict = cv2.resize(frame.image.image_pointer, (300, 300))
+
         #FIXME fix the url
         try:
-            res = requests.post(PredictModule.Url + '/predict/'+self.model, files={'file': img}, params={'width': width, 'height': height})
+            res = requests.post(PredictModule.Url + '/predict/'+self.model, files={'file': img_to_predict}, params={'width': 300, 'height': 300})
             if res.status_code != 200:
                 print('failed to send the image to predict module', flush=True)
                 return
@@ -84,6 +80,10 @@ class ObjectDetectionModel(Model):
             return 
 
         
+        img = frame.image.image_pointer
+        width = frame.image.properties.width
+        height = frame.image.properties.height
+
         #print(res)
         #print(res.json())
         try:


### PR DESCRIPTION
close #39 

### original flow

StreamingModule receive image 
-> resized to 300x300 
-> send to Predictmodule 
-> predictmodule does the inference and send back the result streamimgmodule 
-> if the result match some certain logic, streamingmodule send the resized image (300x300) to webmodule

### new flow

StreamingModule receive image 
-> resized to 300x300 
-> send to Predictmodule 
-> predictmodule does the inference and send back the result streamimgmodule 
-> if the result match some certain logic, streamingmodule send the ORIGINAL image  to webmodule


### note

we still keep the resize 300x300 since large image will introduce more overhead between streaming and predict modules