### PR TITLE
Update patch k8s config strategy

### DIFF
--- a/src/portal/modules/webmodule/backend/vision_on_edge/azure_cascades/models.py
+++ b/src/portal/modules/webmodule/backend/vision_on_edge/azure_cascades/models.py
@@ -82,9 +82,10 @@ class Cascade(models.Model):
                 for cam in configure:
                     for skill in cam['skills']:
                         if int(skill['id']) == int(instance.id):
-                            affected_solutions.append(instance_obj.compute_device.solution_id)
+                            affected_solutions.append(
+                                instance_obj.compute_device.solution_id)
 
-            skill_client.update_config(
+            skill_client.patch_config(
                 group="ai.symphony", plural="skills", name=instance.symphony_id)
 
             logger.warning(f"Updating affected solutions: {affected_solutions}")

--- a/src/portal/modules/webmodule/backend/vision_on_edge/azure_cascades/symphony_client.py
+++ b/src/portal/modules/webmodule/backend/vision_on_edge/azure_cascades/symphony_client.py
@@ -34,6 +34,22 @@ class SymphonySkillClient(SymphonyClient):
         }
         return config_json
 
+    def get_patch_config(self):
+
+        tag_list = self.args.get("tag_list", "")
+        spec = self.args.get("spec", "")
+
+        labels = {}
+        if tag_list:
+            for tag in json.loads(tag_list):
+                labels[tag["name"]] = tag["value"]
+
+        patch_config = [
+            {'op': 'replace', 'path': '/metadata/labels', 'value': labels},
+            {'op': 'replace', 'path': '/spec', 'value': spec},
+        ]
+        return patch_config
+
     def load_symphony_objects(self):
         from .models import Cascade
 

--- a/src/portal/modules/webmodule/backend/vision_on_edge/azure_projects/models.py
+++ b/src/portal/modules/webmodule/backend/vision_on_edge/azure_projects/models.py
@@ -483,7 +483,7 @@ class Project(models.Model):
                 model_client.deploy_config(group="ai.symphony", plural="models")
             else:
                 # update
-                model_client.update_config(
+                model_client.patch_config(
                     group="ai.symphony", plural="models", name=instance.symphony_id)
 
     @staticmethod

--- a/src/portal/modules/webmodule/backend/vision_on_edge/azure_projects/symphony_client.py
+++ b/src/portal/modules/webmodule/backend/vision_on_edge/azure_projects/symphony_client.py
@@ -52,6 +52,21 @@ class SymphonyModelClient(SymphonyClient):
         }
         return config_json
 
+    def get_patch_config(self):
+
+        tag_list = self.args.get("tag_list", "")
+
+        labels = {}
+        if tag_list:
+            for tag in json.loads(tag_list):
+                labels[tag["name"]] = tag["value"]
+
+        # can only patch labels on portal for now
+        patch_config = [
+            {'op': 'replace', 'path': '/metadata/labels', 'value': labels},
+        ]
+        return patch_config
+
     def load_symphony_objects(self):
         from .models import Project
         from ..azure_settings.models import Setting

--- a/src/portal/modules/webmodule/backend/vision_on_edge/cameras/models.py
+++ b/src/portal/modules/webmodule/backend/vision_on_edge/cameras/models.py
@@ -172,7 +172,7 @@ class Camera(models.Model):
             device_client.deploy_config(group="fabric.symphony", plural="devices")
         else:
             # update
-            device_client.update_config(
+            device_client.patch_config(
                 group="fabric.symphony", plural="devices", name=instance.symphony_id)
 
     @staticmethod

--- a/src/portal/modules/webmodule/backend/vision_on_edge/cameras/symphony_client.py
+++ b/src/portal/modules/webmodule/backend/vision_on_edge/cameras/symphony_client.py
@@ -55,6 +55,31 @@ class SymphonyDeviceClient(SymphonyClient):
         }
         return config_json
 
+    def get_patch_config(self):
+
+        allowed_devices = self.args.get("allowed_devices", "")
+        rtsp = self.args.get("rtsp", "")
+        username = self.args.get("username", "")
+        password = self.args.get("password", "")
+        location = self.args.get("location", "")
+        tag_list = self.args.get("tag_list", "")
+
+        device_list = json.loads(allowed_devices)
+        labels = {k: "true" for k in device_list}
+        logger.warning(f"setting camera tags: {tag_list}")
+        if tag_list:
+            for tag in json.loads(tag_list):
+                labels[tag["name"]] = tag["value"]
+
+        patch_config = [
+            {'op': 'replace', 'path': '/metadata/labels', 'value': labels},
+            {'op': 'replace', 'path': '/spec/properties/ip', 'value': rtsp},
+            {'op': 'replace', 'path': '/spec/properties/user', 'value': username},
+            {'op': 'replace', 'path': '/spec/properties/password', 'value': password},
+            {'op': 'replace', 'path': '/spec/properties/location', 'value': location},
+        ]
+        return patch_config
+
     def get_snapshot_url(self, name):
 
         api = self.get_client()

--- a/src/portal/modules/webmodule/backend/vision_on_edge/compute_devices/models.py
+++ b/src/portal/modules/webmodule/backend/vision_on_edge/compute_devices/models.py
@@ -102,7 +102,7 @@ class ComputeDevice(models.Model):
             solution_client.deploy_config(group="solution.symphony", plural="solutions")
         else:
             # update
-            target_client.update_config(
+            target_client.patch_config(
                 group="fabric.symphony", plural="targets", name=instance.symphony_id)
         az_logger.warning(
             "create_compute_device",

--- a/src/portal/modules/webmodule/backend/vision_on_edge/deployments/models.py
+++ b/src/portal/modules/webmodule/backend/vision_on_edge/deployments/models.py
@@ -83,7 +83,8 @@ class Deployment(models.Model):
                 skill_obj = Cascade.objects.get(pk=int(skill['id']))
                 skill_alias = str(uuid.uuid4())[-4:]
                 skill_env.append(f"{skill_obj.symphony_id} as skill-{skill_alias}")
-                skill_params[f"skill-{skill_alias}.rtsp"] = f"rtsp://{device_obj.username}:{device_obj.password}@{device_obj.rtsp.split('rtsp://')[1]}"
+                skill_params[
+                    f"skill-{skill_alias}.rtsp"] = f"rtsp://{device_obj.username}:{device_obj.password}@{device_obj.rtsp.split('rtsp://')[1]}"
                 skill_params[f"skill-{skill_alias}.fps"] = skill_obj.fps
                 skill_params[f"skill-{skill_alias}.device_id"] = device_obj.symphony_id
                 skill_params[f"skill-{skill_alias}.instance_displayname"] = instance.name
@@ -135,7 +136,7 @@ class Deployment(models.Model):
             # update
             solution_client.update_config(
                 group="solution.symphony", plural="solutions", name=instance.compute_device.solution_id)
-            instance_client.update_config(
+            instance_client.patch_config(
                 group="solution.symphony", plural="instances", name=instance.symphony_id)
 
         # monitor iothub messages

--- a/src/portal/modules/webmodule/backend/vision_on_edge/deployments/symphony_client.py
+++ b/src/portal/modules/webmodule/backend/vision_on_edge/deployments/symphony_client.py
@@ -44,6 +44,22 @@ class SymphonyInstanceClient(SymphonyClient):
         }
         return config_json
 
+    def get_patch_config(self):
+
+        params = self.args.get("params", {})
+        tag_list = self.args.get("tag_list", "")
+
+        labels = {}
+        if tag_list:
+            for tag in json.loads(tag_list):
+                labels[tag["name"]] = tag["value"]
+
+        patch_config = [
+            {'op': 'replace', 'path': '/metadata/labels', 'value': labels},
+            {'op': 'replace', 'path': '/spec/parameters', 'value': params}
+        ]
+        return patch_config
+
     def load_symphony_objects(self):
         from .models import Deployment
         from ..cameras.models import Camera


### PR DESCRIPTION
close #74 

Python k8s SDK adopts merge-patch+json by default.
-> change the function to make api_call in k8s client directly to set the merge strategy

Patch would no longer append data to the config but replace the previous one, which would solve the redundant parameters issue.