### PR TITLE
Explicit reference in Step 1 of Setup process

### DIFF
--- a/docs/tutorial/setup-guide.md
+++ b/docs/tutorial/setup-guide.md
@@ -28,8 +28,9 @@ KAN installer script will guide you through the steps of creating related Azure 
 
 ## Setup process 
 
-1. Open your shell terminal ([Azure Cloud Shell](https://learn.microsoft.com/en-us/azure/cloud-shell/overview) recommended).
-2. Download and launch the installer script:
+1. Open your shell terminal ([Azure Cloud Shell](https://learn.microsoft.com/en-us/azure/cloud-shell/overview) recommended). Ensure that you switch to Bash option in Azure Cloud Shell
+![image](https://user-images.githubusercontent.com/4857092/216773245-e7a0b7d1-16af-4ad1-a10a-da6a5a8cdc97.png)
+3. Download and launch the installer script:
    ```bash
    bash <(wget -qO- https://raw.githubusercontent.com/Azure/KAN/main/Installer/kan-installer.sh)
    ```


### PR DESCRIPTION
Azure Cloud Shell has 2 possible options: Bash and PowerShell. If user is using Bash, then Step 2 would work Ok. However, if they are in default option of PowerShell, their attempt to run Step 2 would end up with "The '<' operator is reserved for future use" error. To provide smoother setup experience, would recommend to specify in Step 1 explicitly that the one is to switch to Bash. Thanks!