### PR TITLE
build: libcudnn library for GPU container

### DIFF
--- a/src/edge/EdgeSolution/modules/kanai/dockerfiles/Dockerfile.gpuamd64
+++ b/src/edge/EdgeSolution/modules/kanai/dockerfiles/Dockerfile.gpuamd64
@@ -4,10 +4,12 @@
 #FROM python:3.8-slim-buster
 FROM nvidia/cuda:11.7.0-runtime-ubuntu20.04
 
-COPY kanai/libcudnn/* /usr/local/cuda/lib64/
+# COPY kanai/libcudnn/* /usr/local/cuda/lib64/
 
 RUN apt update
 RUN apt install ffmpeg libsm6 libxext6 -y
+RUN apt install libcudnn8=8.5.0.96-1+cuda11.7
+RUN cp /usr/lib/x86_64-linux-gnu/*cudnn* /usr/local/cuda/lib64/
 RUN apt install wget unzip -y
 RUN apt install python3.8 pip -y
 RUN pip install -U pip

--- a/src/edge/EdgeSolution/modules/kanai/module.json
+++ b/src/edge/EdgeSolution/modules/kanai/module.json
@@ -4,7 +4,7 @@
   "image": {
     "repository": "${CONTAINER_REGISTRY_NAME}/kanai",
     "tag": {
-      "version": "0.41.46",
+      "version": "0.41.47",
       "platforms": {
         "amd64": "./dockerfiles/Dockerfile.amd64",
         "gpuamd64": "./dockerfiles/Dockerfile.gpuamd64",

--- a/src/edge/EdgeSolution/modules/kanai/module.json
+++ b/src/edge/EdgeSolution/modules/kanai/module.json
@@ -4,7 +4,7 @@
   "image": {
     "repository": "${CONTAINER_REGISTRY_NAME}/kanai",
     "tag": {
-      "version": "0.41.47",
+      "version": "0.41.46",
       "platforms": {
         "amd64": "./dockerfiles/Dockerfile.amd64",
         "gpuamd64": "./dockerfiles/Dockerfile.gpuamd64",

--- a/src/edge/EdgeSolution/modules/kanai/requirements-gpu.txt
+++ b/src/edge/EdgeSolution/modules/kanai/requirements-gpu.txt
@@ -14,3 +14,4 @@ httpx
 azure-iot-device
 pytz
 grpcio
+protobuf==3.20.*

--- a/src/edge/EdgeSolution/modules/kanai/requirements-jetson.txt
+++ b/src/edge/EdgeSolution/modules/kanai/requirements-jetson.txt
@@ -11,3 +11,4 @@ httpx
 azure-iot-device
 pytz
 grpcio
+protobuf==3.19.*

--- a/src/edge/EdgeSolution/modules/kanai/requirements-openvino.txt
+++ b/src/edge/EdgeSolution/modules/kanai/requirements-openvino.txt
@@ -11,3 +11,4 @@ httpx
 azure-iot-device
 pytz
 grpcio
+protobuf==3.19.*

--- a/src/edge/EdgeSolution/modules/kanai/requirements.txt
+++ b/src/edge/EdgeSolution/modules/kanai/requirements.txt
@@ -14,3 +14,4 @@ httpx
 azure-iot-device
 pytz
 grpcio
+protobuf==3.20.*


### PR DESCRIPTION
- install libcudnn library instead of copying from local files